### PR TITLE
Invalidate server query cache

### DIFF
--- a/src/WithServerQuery.js
+++ b/src/WithServerQuery.js
@@ -108,9 +108,23 @@ const WithServerQuery = {
     function serverQuery(props) {
       return getInstance(props).execute(props);
     }
+    
+    function invalidate(props) {
+      var key = spec.statics.getKey(props);
+      key = typeId + '~' + key;
+      serverQueries = Object.keys(serverQueries).reduce((acc, k) => {
+        const obj = acc;
+        if (k !== key) {
+          obj[k] = serverQueries[k];
+        }
+        return obj;
+      }, {});
+      return serverQuery(props);
+    };
 
     serverQuery.getInstance = getInstance;
-
+    serverQuery.invalidate = invalidate;
+    
     return serverQuery;
   }
 };


### PR DESCRIPTION
I've added an invalidate function to `WithServerQuery.js`, which can be used as e.g. `MyDomain.get.invalidate({ attr: 'key })`. It'll remove the server query from the `serverQueries` object against the key. It then returns the a fresh version of the query.

Anything naive about this approach? Works for me so far.